### PR TITLE
User Story 1: View Learners and their Enrolled Courses with Progress

### DIFF
--- a/app/Http/Controllers/LearnerProgressController.php
+++ b/app/Http/Controllers/LearnerProgressController.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Learner;
+use App\Models\Course;
+use Illuminate\Http\Request;
+
+class LearnerProgressController extends Controller
+{
+    // Show the dashboard page
+    public function index()
+    {
+        return view('learner-progress.index');
+    }
+
+    // API endpoint: Return learners with their courses and progress
+    public function api()
+    {
+        $learners = Learner::with(['courses' => function($query) {
+            $query->withPivot('progress');
+        }])->get();
+        return response()->json($learners);
+    }
+
+    // API endpoint: Return all courses (for filtering UI)
+    public function courses()
+    {
+        $courses = Course::all(['id', 'name']);
+        return response()->json($courses);
+    }
+}

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http;
+
+use Illuminate\Foundation\Http\Kernel as HttpKernel;
+
+class Kernel extends HttpKernel
+{
+    /**
+     * The application's route middleware groups.
+     *
+     * @var array
+     */
+    protected $middlewareGroups = [
+        'web' => [
+            \App\Http\Middleware\EncryptCookies::class,
+            \Illuminate\Cookie\Middleware\AddQueuedCookiesToResponse::class,
+            \Illuminate\Session\Middleware\StartSession::class,
+            \Illuminate\View\Middleware\ShareErrorsFromSession::class,
+            \App\Http\Middleware\VerifyCsrfToken::class,
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+
+        'api' => [
+            // Uncomment if using Laravel Sanctum
+            // \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
+            'throttle:api',
+            \Illuminate\Routing\Middleware\SubstituteBindings::class,
+        ],
+    ];
+}

--- a/app/Http/Middleware/EncryptCookies.php
+++ b/app/Http/Middleware/EncryptCookies.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
+
+class EncryptCookies extends Middleware
+{
+    // Add cookies that should not be encrypted here
+    // protected $except = [];
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Foundation\Http\Middleware\VerifyCsrfToken as Middleware;
+
+class VerifyCsrfToken extends Middleware
+{
+    // Add URIs that should be excluded from CSRF verification here
+    // protected $except = [];
+}

--- a/app/Models/Learner.php
+++ b/app/Models/Learner.php
@@ -18,4 +18,13 @@ class Learner extends Model
         'firstname',
         'lastname',
     ];
+
+    /**
+     * The courses that the learner is enrolled in.
+     */
+    public function courses()
+    {
+        return $this->belongsToMany(Course::class, 'enrolments', 'learner_id', 'course_id')
+            ->withPivot('progress');
+    }
 }

--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace App\Providers;
+
+use Illuminate\Foundation\Support\Providers\RouteServiceProvider as ServiceProvider;
+use Illuminate\Support\Facades\Route;
+
+class RouteServiceProvider extends ServiceProvider
+{
+    /**
+     * Define route model bindings, pattern filters, etc.
+     */
+    public function boot(): void
+    {
+        $this->routes(function () {
+            Route::middleware('api')
+                ->prefix('api')
+                ->group(base_path('routes/api.php'));
+
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+        });
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Learner Progress Dashboard</title>
+    <link href="https://cdn.jsdelivr.net/npm/tailwindcss@2.2.19/dist/tailwind.min.css" rel="stylesheet">
+    <script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.x.x/dist/cdn.min.js"></script>
+</head>
+<body class="bg-gray-100 min-h-screen">
+    <div class="min-h-screen flex flex-col">
+        @yield('content')
+    </div>
+</body>
+</html>

--- a/resources/views/learner-progress/index.blade.php
+++ b/resources/views/learner-progress/index.blade.php
@@ -1,0 +1,42 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container mx-auto px-4 py-6" x-data="learnerProgress()" x-init="init()">
+    <h1 class="text-2xl font-bold mb-6">Learner Progress Dashboard</h1>
+    <div class="grid gap-6">
+        <!-- Learners List -->
+        <template x-if="learners.length === 0">
+            <div class="text-gray-500">No learners found.</div>
+        </template>
+        <template x-for="learner in learners" :key="learner.id">
+            <div class="bg-white rounded shadow p-4">
+                <h2 class="font-semibold text-lg" x-text="learner.first_name + ' ' + learner.last_name"></h2>
+                <div class="ml-4 mt-2">
+                    <template x-if="learner.courses.length === 0">
+                        <div class="text-gray-400 text-sm">No courses enrolled.</div>
+                    </template>
+                    <template x-for="course in learner.courses" :key="course.id">
+                        <div class="flex justify-between text-sm py-1">
+                            <span x-text="course.name"></span>
+                            <span class="font-mono" x-text="course.pivot.progress_percentage + '%' "></span>
+                        </div>
+                    </template>
+                </div>
+            </div>
+        </template>
+    </div>
+</div>
+
+<!-- Alpine.js logic -->
+<script>
+function learnerProgress() {
+    return {
+        learners: [],
+        async init() {
+            const res = await fetch('/api/learners');
+            this.learners = await res.json();
+        }
+    }
+}
+</script>
+@endsection

--- a/resources/views/learner-progress/index.blade.php
+++ b/resources/views/learner-progress/index.blade.php
@@ -10,15 +10,14 @@
         </template>
         <template x-for="learner in learners" :key="learner.id">
             <div class="bg-white rounded shadow p-4">
-                <h2 class="font-semibold text-lg" x-text="learner.first_name + ' ' + learner.last_name"></h2>
+                <h2 class="font-semibold text-lg" x-text="learner.firstname + ' ' + learner.lastname"></h2>
                 <div class="ml-4 mt-2">
                     <template x-if="learner.courses.length === 0">
                         <div class="text-gray-400 text-sm">No courses enrolled.</div>
                     </template>
                     <template x-for="course in learner.courses" :key="course.id">
                         <div class="flex justify-between text-sm py-1">
-                            <span x-text="course.name"></span>
-                            <span class="font-mono" x-text="course.pivot.progress_percentage + '%' "></span>
+                            <span x-text="course.name + ' (' + (course.pivot.progress ?? 0) + '%)'"></span>
                         </div>
                     </template>
                 </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\LearnerProgressController;
+
+Route::get('/learners', [LearnerProgressController::class, 'api']);
+Route::get('/courses', [LearnerProgressController::class, 'courses']);
+
+// Test route for api
+Route::get('/test-api', function() {
+    return response()->json(['message' => 'api route works']);
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -5,3 +5,7 @@ use Illuminate\Support\Facades\Route;
 Route::get('/', function () {
     return view('welcome');
 });
+
+use App\Http\Controllers\LearnerProgressController;
+
+Route::get('/learner-progress', [LearnerProgressController::class, 'index'])->name('learner-progress');


### PR DESCRIPTION
Given that I am a user on the /learner-progress page
● I can see a list of learners
● Under each learner, I can also see:
● Learner's full name
●  Courses enrolled (with course names)
●  Progress (%) for each course